### PR TITLE
doesn't produce correct result

### DIFF
--- a/src/talib.cpp
+++ b/src/talib.cpp
@@ -105,7 +105,7 @@ static double *V8_TO_DOUBLE_ARRAY(Local<Array> array) {
     
     // Store values in the double array
     for (int i = 0; i < length; i++) {
-        result[i] = Get(array, i).ToLocalChecked()->Uint32Value();
+        result[i] = Get(array, i).ToLocalChecked()->NumberValue();
     }
     
     // Return the double array result


### PR DESCRIPTION
I just did a simple test on SMA but can't seem to get the correct result.

    var close = [29.3,29.5, 29.9];
    talib.execute({
        name: "SMA",
        startIdx: 0,
        endIdx: close.length - 1,
        inReal: close,
        optInTimePeriod: 2,
    }, function (result) {
        console.log(result);
    });

This seems to produce

{ begIndex: 1, nbElement: 2, result: { outReal: [ 29, 29 ] } }

The result shouldn't be [29, 29]. It should be something like [29.4, 29.6999]. 

Something gone wrong somewhere?
