### PR TITLE
Support for FreeBSD. Build of node-talib requires port devel/ta-lib.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,11 @@
                     "../src/lib/lib/libta_libc_csr.a",
                 ]
             }],
+            ['OS=="freebsd"', {
+                "libraries": [
+                    "/usr/local/lib/libta_lib.a"
+                ]
+            }],
             ['OS=="mac"', {
                 'xcode_settings': {
                     'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++'],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "os": [
     "darwin",
     "linux",
+    "freebsd",
     "win32"
   ],
   "scripts": {

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -37,6 +37,12 @@ if (process.platform == 'win32') {
     console.log(stdout, stderr);
   });
 
+} else if (process.platform == 'freebsd') {
+  if (fs.existsSync('/usr/local/lib/libta_lib.a')) {
+    console.log('package devel/ta-lib is installed. No need to build talib functions.')
+  } else {
+    console.error('Please install ta-lib from ports collection: pkg install devel/ta-lib');
+  };
 } else {
 
   var flags = '';


### PR DESCRIPTION
With this commit support for FreeBSD is included.
As a dependency the following port needs to be installed: https://www.freshports.org/devel/ta-lib/
Testing was done with Node.js v12.21.0 on FreeBSD 12.2-RELEASE-p3. All examples were running.